### PR TITLE
fix: ejs data metrics is null when vu not defined

### DIFF
--- a/src/template.ejs
+++ b/src/template.ejs
@@ -298,8 +298,8 @@
           <div class="box metricbox">
             <h4>Virtual Users</h4>
             <i class="fas fa-user icon"></i>
-            <div class="row"><div>Min</div><div><%= data.metrics.vus.values.min %></div></div>
-            <div class="row"><div>Max</div><div><%= data.metrics.vus.values.max %></div></div>
+            <div class="row"><div>Min</div><div><%= data.metrics.vus ? data.metrics.vus.values.min : 1 %></div></div>
+            <div class="row"><div>Max</div><div><%= data.metrics.vus ? data.metrics.vus.values.max : 1 %></div></div>
           </div>
         </div>
 


### PR DESCRIPTION
When generate the report whithout defining VU, fire error.
`ERRO[0007] handleSummary() failed with error "TypeError: ejs:301
    299|             <h4>Virtual Users</h4>
    300|             <i class="fas fa-user icon"></i>
 >> 301|             <div class="row"><div>Min</div><div><%= data.metrics.vus.values.min %></div></div>
    302|             <div class="row"><div>Max</div><div><%= data.metrics.vus.values.max %></div></div>
    303|           </div>
    304|         </div>

Cannot read property 'values' of undefined", falling back to the default summary  source=console
`
Screenshot [https://ibb.co/hBDGf7R](url)